### PR TITLE
Fix missing `GO111MODULE` env for 1.12.x and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ notifications:
 env:
   global:
     - MAKEFLAGS=" -j 2"
+    - GO111MODULE=on

--- a/memviz_test.go
+++ b/memviz_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bradleyjkemp/memviz"
 )
 
+//nolint:structcheck,megacheck
 type basicNumerics struct {
 	uint8      uint8
 	uint32     uint32


### PR DESCRIPTION
Currently, failed TravisCI. Maybe needs `GO111MODULE` env for 1.12.x and master(tip).